### PR TITLE
Enhance cert-manager issuer

### DIFF
--- a/terraform/environment-template/infrastructure/README.md
+++ b/terraform/environment-template/infrastructure/README.md
@@ -27,6 +27,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cert_manager_issuer_project_id"></a> [cert\_manager\_issuer\_project\_id](#output\_cert\_manager\_issuer\_project\_id) | Project ID in which the Cloud DNS zone to manage the DNS entries is located. |
 | <a name="output_cert_manager_sa_account_id"></a> [cert\_manager\_sa\_account\_id](#output\_cert\_manager\_sa\_account\_id) | Account id of the cert-manager Service Account |
 | <a name="output_cert_manager_sa_key_file"></a> [cert\_manager\_sa\_key\_file](#output\_cert\_manager\_sa\_key\_file) | Service Account Key File for cert-manager Service Account |
 | <a name="output_cloud_endpoints_key_file"></a> [cloud\_endpoints\_key\_file](#output\_cloud\_endpoints\_key\_file) | Service Account Key File for Cloud Endpoints Service Account |

--- a/terraform/environment-template/infrastructure/outputs.tf
+++ b/terraform/environment-template/infrastructure/outputs.tf
@@ -85,3 +85,8 @@ output "cert_manager_sa_key_file" {
   description = "Service Account Key File for cert-manager Service Account"
   sensitive   = true
 }
+
+output "cert_manager_issuer_project_id" {
+  value        = module.infrastructure.cert_manager_issuer_project_id
+  description = "Project ID in which the Cloud DNS zone to manage the DNS entries is located."
+}

--- a/terraform/environment-template/software/main.tf
+++ b/terraform/environment-template/software/main.tf
@@ -15,6 +15,7 @@ module "software" {
   cloud_endpoints_key_file            = data.terraform_remote_state.infrastructure.outputs.cloud_endpoints_key_file
   cert_manager_sa_account_id          = try(data.terraform_remote_state.infrastructure.outputs.cert_manager_sa_account_id[0], "")
   cert_manager_sa_key_file            = try(data.terraform_remote_state.infrastructure.outputs.cert_manager_sa_key_file[0], "")
+  cert_manager_issuer_project_id      = try(data.terraform_remote_state.infrastructure.outputs.cert_manager_issuer_project_id[0], "")
   hono_tls_key_from_storage           = try(data.terraform_remote_state.software.outputs.hono_tls_key_in_storage, null)
   hono_tls_crt_from_storage           = try(data.terraform_remote_state.software.outputs.hono_tls_crt_in_storage, null)
   hono_tls_key                        = try(file("${path.module}/hono_tls.key"), null)

--- a/terraform/infrastructure/README.md
+++ b/terraform/infrastructure/README.md
@@ -29,6 +29,8 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cert_manager_issuer_project_id"></a> [cert\_manager\_issuer\_project\_id](#input\_cert\_manager\_issuer\_project\_id) | Project ID in which the Cloud DNS zone to manage the DNS entries is located. Defaults to use the same project ID as the Hono instance. | `string` | `null` | no |
+| <a name="input_cert_manager_sa_account_id"></a> [cert\_manager\_sa\_account\_id](#input\_cert\_manager\_sa\_account\_id) | ID under which the cert-manager service account is going to be created. | `string` | `"hono-cert-manager-dns-solver"` | no |
 | <a name="input_enable_cert_manager"></a> [enable\_cert\_manager](#input\_enable\_cert\_manager) | Enables the service account needed for the use of cert manager | `bool` | `false` | no |
 | <a name="input_enable_http_ip_creation"></a> [enable\_http\_ip\_creation](#input\_enable\_http\_ip\_creation) | Used to enable the creation of a static ip for the http adapter | `string` | `false` | no |
 | <a name="input_enable_mqtt_ip_creation"></a> [enable\_mqtt\_ip\_creation](#input\_enable\_mqtt\_ip\_creation) | Used to enable the creation of a static ip for the mqtt adapter | `string` | `true` | no |
@@ -77,6 +79,7 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cert_manager_issuer_project_id"></a> [cert\_manager\_issuer\_project\_id](#output\_cert\_manager\_issuer\_project\_id) | Project ID in which the Cloud DNS zone to manage the DNS entries is located. |
 | <a name="output_cert_manager_sa_account_id"></a> [cert\_manager\_sa\_account\_id](#output\_cert\_manager\_sa\_account\_id) | Account id of the cert-manager Service Account |
 | <a name="output_cert_manager_sa_key_file"></a> [cert\_manager\_sa\_key\_file](#output\_cert\_manager\_sa\_key\_file) | Service Account Key File for cert-manager Service Account |
 | <a name="output_cloud_endpoints_key_file"></a> [cloud\_endpoints\_key\_file](#output\_cloud\_endpoints\_key\_file) | Service Account Key File for Cloud Endpoints Service Account |

--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -58,11 +58,13 @@ module "cloud_sql" {
 }
 
 module "google_iam" {
-  source                       = "../modules/google_iam"
-  service_name_communication   = module.cloud_endpoint.service_name_communication
-  project_id                   = var.project_id
-  service_account_roles_gke_sa = var.service_account_roles_gke_sa
-  enable_cert_manager          = var.enable_cert_manager
+  source                          = "../modules/google_iam"
+  service_name_communication      = module.cloud_endpoint.service_name_communication
+  project_id                      = var.project_id
+  service_account_roles_gke_sa    = var.service_account_roles_gke_sa
+  enable_cert_manager             = var.enable_cert_manager
+  cert_manager_sa_account_id      = var.cert_manager_sa_account_id
+  cert_manager_issuer_project_id  = var.cert_manager_issuer_project_id
 }
 
 module "gke" {

--- a/terraform/infrastructure/outputs.tf
+++ b/terraform/infrastructure/outputs.tf
@@ -80,3 +80,8 @@ output "cert_manager_sa_key_file" {
   description = "Service Account Key File for cert-manager Service Account"
   sensitive   = true
 }
+
+output "cert_manager_issuer_project_id" {
+  value        = module.google_iam.cert_manager_issuer_project_id
+  description = "Project ID in which the Cloud DNS zone to manage the DNS entries is located."
+}

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -211,6 +211,18 @@ variable "enable_cert_manager" {
   default     = false
 }
 
+variable "cert_manager_sa_account_id" {
+  type        = string
+  description = "ID under which the cert-manager service account is going to be created."
+  default     = "hono-cert-manager-dns-solver"
+}
+
+variable "cert_manager_issuer_project_id" {
+  type        = string
+  description = "Project ID in which the Cloud DNS zone to manage the DNS entries is located. Defaults to use the same project ID as the Hono instance."
+  default     = null
+}
+
 variable "sql_instance_backup_enabled" {
   type        = bool
   description = "Whether this Cloud SQL instance should enable automatic backups."

--- a/terraform/modules/cert_manager/README.md
+++ b/terraform/modules/cert_manager/README.md
@@ -36,6 +36,7 @@ No modules.
 | <a name="input_cert_manager_email"></a> [cert\_manager\_email](#input\_cert\_manager\_email) | E-Mail address to contact in case something goes wrong with the certificate renewal. | `string` | n/a | yes |
 | <a name="input_cert_manager_issuer_kind"></a> [cert\_manager\_issuer\_kind](#input\_cert\_manager\_issuer\_kind) | Kind of the cert-manager issuer (Issuer or ClusterIssuer). | `string` | n/a | yes |
 | <a name="input_cert_manager_issuer_name"></a> [cert\_manager\_issuer\_name](#input\_cert\_manager\_issuer\_name) | Name of the cert-manager issuer. | `string` | n/a | yes |
+| <a name="input_cert_manager_issuer_project_id"></a> [cert\_manager\_issuer\_project\_id](#input\_cert\_manager\_issuer\_project\_id) | Project ID in which the Cloud DNS zone to manage the DNS entries is located. | `string` | n/a | yes |
 | <a name="input_cert_manager_namespace"></a> [cert\_manager\_namespace](#input\_cert\_manager\_namespace) | Namespace of the cert manager deployment. | `string` | n/a | yes |
 | <a name="input_cert_manager_sa_account_id"></a> [cert\_manager\_sa\_account\_id](#input\_cert\_manager\_sa\_account\_id) | Account id of the cert-manager Service Account. | `string` | n/a | yes |
 | <a name="input_cert_manager_sa_key_file"></a> [cert\_manager\_sa\_key\_file](#input\_cert\_manager\_sa\_key\_file) | Service Account Key File for cert-manager Service Account. | `string` | n/a | yes |
@@ -43,7 +44,6 @@ No modules.
 | <a name="input_hono_domain_managed_secret_name"></a> [hono\_domain\_managed\_secret\_name](#input\_hono\_domain\_managed\_secret\_name) | Name of the kubernetes secret for the hono domain (wildcard) managed by cert-manager. | `string` | n/a | yes |
 | <a name="input_hono_namespace"></a> [hono\_namespace](#input\_hono\_namespace) | Namespace of the hono deployment. | `string` | n/a | yes |
 | <a name="input_hono_trust_store_config_map_name"></a> [hono\_trust\_store\_config\_map\_name](#input\_hono\_trust\_store\_config\_map\_name) | Name of the kubernetes trust store config map for the hono deployments managed by trust-manager. | `string` | n/a | yes |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID in which the cluster is present | `string` | n/a | yes |
 | <a name="input_trust_manager_version"></a> [trust\_manager\_version](#input\_trust\_manager\_version) | Version of the chart to deploy. | `string` | n/a | yes |
 | <a name="input_wildcard_domain"></a> [wildcard\_domain](#input\_wildcard\_domain) | The wildcard domain the secret will be maintained for (e.g. *.root-domain.com). | `string` | n/a | yes |
 

--- a/terraform/modules/cert_manager/main.tf
+++ b/terraform/modules/cert_manager/main.tf
@@ -49,7 +49,7 @@ resource "kubectl_manifest" "issuer_letsencrypt_prod" {
           {
             "dns01" = {
               "cloudDNS" = {
-                "project" = var.project_id
+                "project" = var.cert_manager_issuer_project_id
                 "serviceAccountSecretRef" = {
                   "name" = var.cert_manager_sa_account_id
                   "key" = "key.json"

--- a/terraform/modules/cert_manager/variables.tf
+++ b/terraform/modules/cert_manager/variables.tf
@@ -1,8 +1,3 @@
-variable "project_id" {
-  type        = string
-  description = "Project ID in which the cluster is present"
-}
-
 variable "hono_namespace" {
   type        = string
   description = "Namespace of the hono deployment."
@@ -31,6 +26,11 @@ variable "cert_manager_issuer_kind" {
 variable "cert_manager_issuer_name" {
   type        = string
   description = "Name of the cert-manager issuer."
+}
+
+variable "cert_manager_issuer_project_id" {
+  type        = string
+  description = "Project ID in which the Cloud DNS zone to manage the DNS entries is located."
 }
 
 variable "cert_manager_email" {

--- a/terraform/modules/google_iam/README.md
+++ b/terraform/modules/google_iam/README.md
@@ -29,6 +29,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cert_manager_issuer_project_id"></a> [cert\_manager\_issuer\_project\_id](#input\_cert\_manager\_issuer\_project\_id) | Project ID in which the Cloud DNS zone to manage the DNS entries is located. Defaults to use the same project ID as the Hono instance. | `string` | n/a | yes |
+| <a name="input_cert_manager_sa_account_id"></a> [cert\_manager\_sa\_account\_id](#input\_cert\_manager\_sa\_account\_id) | ID under which the cert-manager service account is going to be created. | `string` | n/a | yes |
 | <a name="input_enable_cert_manager"></a> [enable\_cert\_manager](#input\_enable\_cert\_manager) | Enables the service account needed for the use of cert manager. | `bool` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 | <a name="input_service_account_roles_gke_sa"></a> [service\_account\_roles\_gke\_sa](#input\_service\_account\_roles\_gke\_sa) | Additional roles to be added to the service account. | `list(string)` | n/a | yes |
@@ -38,6 +40,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cert_manager_issuer_project_id"></a> [cert\_manager\_issuer\_project\_id](#output\_cert\_manager\_issuer\_project\_id) | Project ID in which the Cloud DNS zone to manage the DNS entries is located. |
 | <a name="output_cert_manager_sa_account_id"></a> [cert\_manager\_sa\_account\_id](#output\_cert\_manager\_sa\_account\_id) | Account id of the cert-manager Service Account |
 | <a name="output_cert_manager_sa_key_file"></a> [cert\_manager\_sa\_key\_file](#output\_cert\_manager\_sa\_key\_file) | Service Account Key File for cert-manager Service Account |
 | <a name="output_cloud_endpoints_key_file"></a> [cloud\_endpoints\_key\_file](#output\_cloud\_endpoints\_key\_file) | Service Account Key File for Cloud Endpoints Service Account |

--- a/terraform/modules/google_iam/main.tf
+++ b/terraform/modules/google_iam/main.tf
@@ -15,6 +15,7 @@ resource "google_project_iam_member" "gke_service_account_roles" {
 
 # Creating the Service Account for Cloud Endpoints
 resource "google_service_account" "cloud_endpoints_sa" {
+  project      = var.project_id
   account_id   = "hono-cloud-endpoint-manager"
   display_name = "hono-cloud-endpoint-manager"
 }
@@ -39,14 +40,15 @@ resource "google_service_account_key" "endpoints_sa_key" {
 # Creating the Service Account for cert-manager
 resource "google_service_account" "cert_manager_sa" {
   count        = var.enable_cert_manager ? 1 : 0
-  account_id   = "hono-cert-manager-dns-solver"
-  display_name = "hono-cert-manager-dns-solver"
+  project      = var.cert_manager_issuer_project_id != null ? var.cert_manager_issuer_project_id : var.project_id
+  account_id   = var.cert_manager_sa_account_id
+  display_name = var.cert_manager_sa_account_id
 }
 
 # Setting IAM Roles for cert-manager Service Account
 resource "google_project_iam_member" "cert_manager_sa_roles" {
   count    = var.enable_cert_manager ? 1 : 0
-  project  = var.project_id
+  project  = var.cert_manager_issuer_project_id != null ? var.cert_manager_issuer_project_id : var.project_id
   role     = "roles/dns.admin"
   member   = google_service_account.cert_manager_sa[0].member
 }

--- a/terraform/modules/google_iam/outputs.tf
+++ b/terraform/modules/google_iam/outputs.tf
@@ -29,3 +29,8 @@ output "cert_manager_sa_key_file" {
   description = "Service Account Key File for cert-manager Service Account"
   sensitive   = true
 }
+
+output "cert_manager_issuer_project_id" {
+  value        = google_service_account.cert_manager_sa[*].project
+  description = "Project ID in which the Cloud DNS zone to manage the DNS entries is located."
+}

--- a/terraform/modules/google_iam/variables.tf
+++ b/terraform/modules/google_iam/variables.tf
@@ -16,3 +16,13 @@ variable "enable_cert_manager" {
   type        = bool
   description = "Enables the service account needed for the use of cert manager."
 }
+
+variable "cert_manager_sa_account_id" {
+  type        = string
+  description = "ID under which the cert-manager service account is going to be created."
+}
+
+variable "cert_manager_issuer_project_id" {
+  type        = string
+  description = "Project ID in which the Cloud DNS zone to manage the DNS entries is located. Defaults to use the same project ID as the Hono instance."
+}

--- a/terraform/software/README.md
+++ b/terraform/software/README.md
@@ -28,6 +28,7 @@ No resources.
 | <a name="input_cert_manager_email"></a> [cert\_manager\_email](#input\_cert\_manager\_email) | E-Mail address to contact in case something goes wrong with the certificate renewal. | `string` | n/a | yes |
 | <a name="input_cert_manager_issuer_kind"></a> [cert\_manager\_issuer\_kind](#input\_cert\_manager\_issuer\_kind) | Kind of the cert-manager issuer (Issuer or ClusterIssuer). | `string` | `"ClusterIssuer"` | no |
 | <a name="input_cert_manager_issuer_name"></a> [cert\_manager\_issuer\_name](#input\_cert\_manager\_issuer\_name) | Name of the cert-manager issuer. | `string` | `"letsencrypt-prod"` | no |
+| <a name="input_cert_manager_issuer_project_id"></a> [cert\_manager\_issuer\_project\_id](#input\_cert\_manager\_issuer\_project\_id) | Project ID in which the Cloud DNS zone to manage the DNS entries is located. | `string` | n/a | yes |
 | <a name="input_cert_manager_namespace"></a> [cert\_manager\_namespace](#input\_cert\_manager\_namespace) | namespace of the cert manager deployment. | `string` | `"cert-manager"` | no |
 | <a name="input_cert_manager_sa_account_id"></a> [cert\_manager\_sa\_account\_id](#input\_cert\_manager\_sa\_account\_id) | Account id of the cert-manager Service Account. | `string` | n/a | yes |
 | <a name="input_cert_manager_sa_key_file"></a> [cert\_manager\_sa\_key\_file](#input\_cert\_manager\_sa\_key\_file) | Service Account Key File for cert-manager Service Account. | `string` | n/a | yes |

--- a/terraform/software/main.tf
+++ b/terraform/software/main.tf
@@ -49,12 +49,12 @@ module "hono" {
 module "cert-manager" {
   source                              = "../modules/cert_manager"
   count                               = var.enable_cert_manager ? 1 : 0
-  project_id                          = var.project_id
   hono_namespace                      = var.hono_namespace
   cert_manager_namespace              = var.cert_manager_namespace
   cert_manager_version                = var.cert_manager_version
   cert_manager_issuer_kind            = var.cert_manager_issuer_kind
   cert_manager_issuer_name            = var.cert_manager_issuer_name
+  cert_manager_issuer_project_id      = var.cert_manager_issuer_project_id
   cert_manager_email                  = var.cert_manager_email
   cert_manager_sa_account_id          = var.cert_manager_sa_account_id
   cert_manager_sa_key_file            = var.cert_manager_sa_key_file

--- a/terraform/software/variables.tf
+++ b/terraform/software/variables.tf
@@ -172,6 +172,11 @@ variable "cert_manager_issuer_name" {
   default     = "letsencrypt-prod"
 }
 
+variable "cert_manager_issuer_project_id" {
+  type        = string
+  description = "Project ID in which the Cloud DNS zone to manage the DNS entries is located."
+}
+
 variable "cert_manager_email" {
   type        = string
   description = "E-Mail address to contact in case something goes wrong with the certificate renewal."


### PR DESCRIPTION
Added cert_manager_issuer_project_id variable to make it possible to use the cert-manager even if the domain is managed in a different google project than the one hono is deployed to.