### PR TITLE
Custom internal certs and trust store config maps

### DIFF
--- a/terraform/modules/cert_manager/README.md
+++ b/terraform/modules/cert_manager/README.md
@@ -21,8 +21,10 @@ No modules.
 | Name | Type |
 |------|------|
 | [helm_release.cert-manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.trust-manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.certificate](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.issuer_letsencrypt_prod](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.trust-bundle](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_secret.cert_manager_sa_key_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 
 ## Inputs
@@ -40,7 +42,9 @@ No modules.
 | <a name="input_cert_manager_version"></a> [cert\_manager\_version](#input\_cert\_manager\_version) | Version of the chart to deploy. | `string` | n/a | yes |
 | <a name="input_hono_domain_managed_secret_name"></a> [hono\_domain\_managed\_secret\_name](#input\_hono\_domain\_managed\_secret\_name) | Name of the kubernetes secret for the hono domain (wildcard) managed by cert-manager. | `string` | n/a | yes |
 | <a name="input_hono_namespace"></a> [hono\_namespace](#input\_hono\_namespace) | Namespace of the hono deployment. | `string` | n/a | yes |
+| <a name="input_hono_trust_store_config_map_name"></a> [hono\_trust\_store\_config\_map\_name](#input\_hono\_trust\_store\_config\_map\_name) | Name of the kubernetes trust store config map for the hono deployments managed by trust-manager. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID in which the cluster is present | `string` | n/a | yes |
+| <a name="input_trust_manager_version"></a> [trust\_manager\_version](#input\_trust\_manager\_version) | Version of the chart to deploy. | `string` | n/a | yes |
 | <a name="input_wildcard_domain"></a> [wildcard\_domain](#input\_wildcard\_domain) | The wildcard domain the secret will be maintained for (e.g. *.root-domain.com). | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/modules/cert_manager/variables.tf
+++ b/terraform/modules/cert_manager/variables.tf
@@ -18,6 +18,11 @@ variable "cert_manager_version" {
   description = "Version of the chart to deploy."
 }
 
+variable "trust_manager_version" {
+  type        = string
+  description = "Version of the chart to deploy."
+}
+
 variable "cert_manager_issuer_kind" {
   type        = string
   description = "Kind of the cert-manager issuer (Issuer or ClusterIssuer)."
@@ -62,4 +67,9 @@ variable "cert_manager_cert_renew_before" {
 variable "wildcard_domain" {
   type        = string
   description = "The wildcard domain the secret will be maintained for (e.g. *.root-domain.com)."
+}
+
+variable "hono_trust_store_config_map_name" {
+  type        = string
+  description = "Name of the kubernetes trust store config map for the hono deployments managed by trust-manager."
 }

--- a/terraform/modules/hono/README.md
+++ b/terraform/modules/hono/README.md
@@ -43,6 +43,7 @@ No modules.
 | <a name="input_hono_tls_crt_from_storage"></a> [hono\_tls\_crt\_from\_storage](#input\_hono\_tls\_crt\_from\_storage) | Content of the hono domain tls Cert File from storage bucket | `string` | n/a | yes |
 | <a name="input_hono_tls_key"></a> [hono\_tls\_key](#input\_hono\_tls\_key) | Content of the hono domain tls Key File | `string` | n/a | yes |
 | <a name="input_hono_tls_key_from_storage"></a> [hono\_tls\_key\_from\_storage](#input\_hono\_tls\_key\_from\_storage) | Content of the hono domain tls Key File from storage bucket | `string` | n/a | yes |
+| <a name="input_hono_trust_store_config_map_name"></a> [hono\_trust\_store\_config\_map\_name](#input\_hono\_trust\_store\_config\_map\_name) | Name of the kubernetes trust store config map for the hono deployments managed by trust-manager. | `string` | n/a | yes |
 | <a name="input_http_static_ip"></a> [http\_static\_ip](#input\_http\_static\_ip) | static ip address for the http loadbalancer | `string` | n/a | yes |
 | <a name="input_mqtt_static_ip"></a> [mqtt\_static\_ip](#input\_mqtt\_static\_ip) | static ip address for the mqtt loadbalancer | `string` | n/a | yes |
 | <a name="input_oauth_app_name"></a> [oauth\_app\_name](#input\_oauth\_app\_name) | Name of the OAuth Application | `string` | n/a | yes |

--- a/terraform/modules/hono/main.tf
+++ b/terraform/modules/hono/main.tf
@@ -26,6 +26,7 @@ locals {
             loadBalancerIP = var.http_static_ip # sets a static IP loadbalancerIP for http adapter
           }
           tlsKeysSecret = var.cert_manager_enabled ? var.hono_domain_managed_secret_name : var.hono_domain_secret_name
+          tlsTrustStoreConfigMap = var.cert_manager_enabled ? var.hono_trust_store_config_map_name : "example"
         }
         mqtt = {
           enabled = var.enable_mqtt_adapter
@@ -33,14 +34,24 @@ locals {
             loadBalancerIP = var.mqtt_static_ip # sets a static IP loadbalancerIP for mqtt adapter
           }
           tlsKeysSecret = var.cert_manager_enabled ? var.hono_domain_managed_secret_name : var.hono_domain_secret_name
+          tlsTrustStoreConfigMap = var.cert_manager_enabled ? var.hono_trust_store_config_map_name : "example"
         }
       }
+      authServer = {
+        tlsKeysSecret = var.cert_manager_enabled ? var.hono_domain_managed_secret_name : var.hono_domain_secret_name
+      }
       deviceRegistryExample = {
+        tlsKeysSecret = var.cert_manager_enabled ? var.hono_domain_managed_secret_name : var.hono_domain_secret_name
+        tlsTrustStoreConfigMap = var.cert_manager_enabled ? var.hono_trust_store_config_map_name : "example"
         # sets database connection config
         jdbcBasedDeviceRegistry = {
           tenant   = local.database_block
           registry = local.database_block
         }
+      }
+      commandRouterService = {
+        tlsKeysSecret = var.cert_manager_enabled ? var.hono_domain_managed_secret_name : var.hono_domain_secret_name
+        tlsTrustStoreConfigMap = var.cert_manager_enabled ? var.hono_trust_store_config_map_name : "example"
       }
       deviceCommunication = {
         app = {

--- a/terraform/modules/hono/variables.tf
+++ b/terraform/modules/hono/variables.tf
@@ -130,6 +130,11 @@ variable "hono_domain_managed_secret_name" {
   description = "Name of the kubernetes secret for the hono domain (wildcard) in case it is managed by cert-manager"
 }
 
+variable "hono_trust_store_config_map_name" {
+  type        = string
+  description = "Name of the kubernetes trust store config map for the hono deployments managed by trust-manager."
+}
+
 variable "oauth_client_id" {
   type = string
   description = "The Google OAuth 2.0 client ID used in the Identity-Aware-Proxy (IAP)"

--- a/terraform/software/README.md
+++ b/terraform/software/README.md
@@ -49,6 +49,7 @@ No resources.
 | <a name="input_hono_tls_crt_from_storage"></a> [hono\_tls\_crt\_from\_storage](#input\_hono\_tls\_crt\_from\_storage) | Content of the hono domain tls Cert File from storage bucket | `string` | n/a | yes |
 | <a name="input_hono_tls_key"></a> [hono\_tls\_key](#input\_hono\_tls\_key) | Content of the hono domain tls Key File | `string` | n/a | yes |
 | <a name="input_hono_tls_key_from_storage"></a> [hono\_tls\_key\_from\_storage](#input\_hono\_tls\_key\_from\_storage) | Content of the hono domain tls Key File from storage bucket | `string` | n/a | yes |
+| <a name="input_hono_trust_store_config_map_name"></a> [hono\_trust\_store\_config\_map\_name](#input\_hono\_trust\_store\_config\_map\_name) | Name of the kubernetes trust store config map for the hono deployments managed by trust-manager. | `string` | `"hono-trust-store-config-map"` | no |
 | <a name="input_http_static_ip"></a> [http\_static\_ip](#input\_http\_static\_ip) | static ip address for the http loadbalancer | `string` | n/a | yes |
 | <a name="input_mqtt_static_ip"></a> [mqtt\_static\_ip](#input\_mqtt\_static\_ip) | static ip address for the mqtt loadbalancer | `string` | n/a | yes |
 | <a name="input_oauth_app_name"></a> [oauth\_app\_name](#input\_oauth\_app\_name) | Name of the Application | `string` | n/a | yes |
@@ -62,6 +63,7 @@ No resources.
 | <a name="input_sql_ip"></a> [sql\_ip](#input\_sql\_ip) | URL of the Postgres Database | `string` | n/a | yes |
 | <a name="input_sql_user"></a> [sql\_user](#input\_sql\_user) | username of the sql database username | `string` | n/a | yes |
 | <a name="input_ssl_policy_name"></a> [ssl\_policy\_name](#input\_ssl\_policy\_name) | Name of the SSL policy for external ingress. | `string` | n/a | yes |
+| <a name="input_trust_manager_version"></a> [trust\_manager\_version](#input\_trust\_manager\_version) | Version of the chart to deploy. | `string` | `"0.5.0"` | no |
 | <a name="input_wildcard_domain"></a> [wildcard\_domain](#input\_wildcard\_domain) | The wildcard domain the secret will be maintained for (e.g. *.root-domain.com). | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/software/main.tf
+++ b/terraform/software/main.tf
@@ -37,6 +37,7 @@ module "hono" {
   cloud_endpoints_key_file            = var.cloud_endpoints_key_file
   hono_domain_secret_name             = var.hono_domain_secret_name
   hono_domain_managed_secret_name     = var.hono_domain_managed_secret_name
+  hono_trust_store_config_map_name    = var.hono_trust_store_config_map_name
   oauth_client_id                     = var.oauth_client_id
   oauth_client_secret                 = var.oauth_client_secret
   cert_manager_enabled                = var.enable_cert_manager
@@ -61,6 +62,8 @@ module "cert-manager" {
   cert_manager_cert_renew_before      = var.cert_manager_cert_renew_before
   hono_domain_managed_secret_name     = var.hono_domain_managed_secret_name
   wildcard_domain                     = var.wildcard_domain
+  trust_manager_version               = var.trust_manager_version
+  hono_trust_store_config_map_name    = var.hono_trust_store_config_map_name
 
   depends_on = [module.namespace]
 }

--- a/terraform/software/variables.tf
+++ b/terraform/software/variables.tf
@@ -205,6 +205,18 @@ variable "wildcard_domain" {
   description = "The wildcard domain the secret will be maintained for (e.g. *.root-domain.com)."
 }
 
+variable "trust_manager_version" {
+  type        = string
+  description = "Version of the chart to deploy."
+  default     = "0.5.0"
+}
+
+variable "hono_trust_store_config_map_name" {
+  type        = string
+  description = "Name of the kubernetes trust store config map for the hono deployments managed by trust-manager."
+  default     = "hono-trust-store-config-map"
+}
+
 variable "ssl_policy_name" {
   type = string
   description = "Name of the SSL policy for external ingress."


### PR DESCRIPTION
* added domain secret as tlsKeysSecret to authServer, deviceRegistryExample and commandRouterService
* added trust-manager to manage trust store config map in case cert-manager is used