### PR TITLE
Add hono module to dependencies of load-balancer module

### DIFF
--- a/terraform/software/main.tf
+++ b/terraform/software/main.tf
@@ -96,5 +96,5 @@ module "load-balancer" {
   advanced_load_balancer      = var.mqtt_adapter.advanced_load_balancer
   mqtt_static_ip              = var.mqtt_static_ip
 
-  depends_on = [module.namespace]
+  depends_on = [module.namespace, module.hono]
 }


### PR DESCRIPTION
Add the hono module to the dependencies of the load-balancer module to ensure that the MQTT adapter IP is released by the MQTT adapter service before trying to start the HAProxy.