### PR TITLE
Add cloud trace agent role to gke service account

### DIFF
--- a/terraform/modules/google_iam/locals.tf
+++ b/terraform/modules/google_iam/locals.tf
@@ -4,6 +4,7 @@ locals {
     "roles/pubsub.editor",
     "roles/iam.serviceAccountOpenIdTokenCreator",
     "roles/monitoring.dashboardViewer",
-    "roles/container.nodeServiceAccount"
+    "roles/container.nodeServiceAccount",
+    "roles/cloudtrace.agent"
   ])
 }


### PR DESCRIPTION
Add the cloud trace agent role to the gke service account to enable traces to be send to the cloud trace api